### PR TITLE
feat: AcoustID + MusicBrainz fallback identification (#2)

### DIFF
--- a/DOCS/ARCHITECTURE.md
+++ b/DOCS/ARCHITECTURE.md
@@ -14,10 +14,10 @@ that are already complete.
 
 | Stage | Module | Entry function | What it does |
 |---|---|---|---|
-| 1 | `pipeline/identify.py` | `run_identification()` | Walks source path for MP3s, computes MD5 hash for dedup, calls ShazamIO to fingerprint each file, writes results to DB |
+| 1 | `pipeline/identify.py` | `run_identification()` | Walks source path for MP3s, computes MD5 hash for dedup, calls ShazamIO to fingerprint each file; falls back to collection-fix detection for no_match files |
 | 2 | `pipeline/review.py` | `run_review()` | Interactive terminal CLI for `no_match` files — play, skip, or enter metadata manually |
 | 3 | `pipeline/tagger.py` | `run_tagging()` | Reads `identified` rows from DB, writes ID3 tags into each MP3 using Mutagen, downloads cover art |
-| 4 | `pipeline/organizer.py` | `run_organization()` | Reads `tagged` rows from DB, renames and moves each file to `Music/<Language>/<Year>/<Album>/` |
+| 4 | `pipeline/organizer.py` | `run_organization()` | Reads `tagged` rows from DB, renames and moves each file to `Music/<Language>/<Year>/<Album>/` or `Music/<Language>/Collections/<Album>/` |
 
 ---
 
@@ -31,9 +31,15 @@ and write to `music.db` goes through a function in this module. No other module 
 SQL. Exports: `get_connection`, `generate_song_id`, `insert_song`, `update_song`,
 `get_songs_by_status`, `song_exists_by_hash`, `create_run`, `finish_run`, `get_run_summary`.
 
+**`pipeline/collection.py`** — Collection-fix detection. Applies regex patterns to
+filenames to extract song title and album name from conventions like `(from Minnale)` or
+`[from Kadal]`. Called by `identify.py` as a fallback when Shazam returns no match.
+Exports `extract_collection_clue(file_path)`.
+
 **`pipeline/identify.py`** — Stage 1. Owns file discovery (`walk_mp3s`), MD5 hashing
-(`compute_md5`), language detection from path (`detect_language`), ShazamIO calls, and
-the short-file guard. Must never import from `tagger.py` or `organizer.py`.
+(`compute_md5`), language detection from path (`detect_language`), ShazamIO calls, the
+short-file guard, and the collection-fix fallback. Must never import from `tagger.py` or
+`organizer.py`.
 
 **`pipeline/review.py`** — Stage 2. Owns the interactive review loop, override parsing
 (`parse_override`), and audio playback (`play_file`). Reads `no_match` rows from DB;
@@ -65,8 +71,9 @@ mp3-organizer-pipeline/
 ├── pipeline/
 │   ├── __init__.py
 │   ├── config.py          # Constants, paths, tunable settings
+│   ├── collection.py      # Collection-fix detection (filename pattern extraction)
 │   ├── db.py              # All SQLite operations (single source of truth)
-│   ├── identify.py        # Stage 1 — ShazamIO recognition
+│   ├── identify.py        # Stage 1 — ShazamIO recognition + collection-fix fallback
 │   ├── review.py          # Stage 2 — Interactive manual review CLI
 │   ├── tagger.py          # Stage 3 — Mutagen ID3 tag write
 │   ├── organizer.py       # Stage 4 — Rename + move to output folder
@@ -108,7 +115,8 @@ mp3-organizer-pipeline/
 | Transition | Triggered by |
 |---|---|
 | `pending` → `identified` | ShazamIO returns a match in Stage 1 |
-| `pending` → `no_match` | ShazamIO returns no match, or file too short (<8s) |
+| `pending` → `identified` (collection-fix) | Shazam fails but filename contains a `from <Album>` pattern |
+| `pending` → `no_match` | Shazam returns no match and no collection pattern found, or file too short (<8s) |
 | `pending` → `error` | Unhandled exception in Stage 1 |
 | `no_match` → `identified` | User enters metadata in `--review` mode (Stage 2) |
 | `identified` → `tagged` | Stage 3 writes ID3 tags successfully |
@@ -155,6 +163,18 @@ Missing fields fall back gracefully:
 - No year → `Unknown Year`
 - No album → `Unknown Album`
 - No title → `song_id` (e.g. `max-000042`)
+
+**Collection-fix songs** (identified from filename patterns, no year known) go to:
+
+```
+Music/<Language>/Collections/<Album>/<Title>.mp3
+```
+
+Example:
+```
+Music/Tamil/Collections/Minnale/Vaseegara.mp3
+Music/Hindi/Collections/Muqaddar Ka Sikandar/O Saathi Re.mp3
+```
 
 Characters illegal in filenames (`/ \ : * ? " < > |`) are replaced with `_`.
 Parentheses, brackets, ampersands, hyphens, exclamation marks, and Unicode (Tamil
@@ -206,6 +226,8 @@ runs/2026-03-21_14-32-00/
 | `python3 main.py --review --limit N` | Review only next N unmatched files |
 | `python3 main.py --stats` | Print DB summary — no files touched |
 | `python3 main.py --check` | Verify DB tables exist — nothing else |
+| `python3 main.py --move` | Tag and move all identified songs (stages 3+4, no source needed) |
+| `python3 main.py --zeroise` | Clear all songs and runs from the database (asks for confirmation) |
 
 ---
 

--- a/DOCS/ARCHITECTURE.md
+++ b/DOCS/ARCHITECTURE.md
@@ -31,6 +31,11 @@ and write to `music.db` goes through a function in this module. No other module 
 SQL. Exports: `get_connection`, `generate_song_id`, `insert_song`, `update_song`,
 `get_songs_by_status`, `song_exists_by_hash`, `create_run`, `finish_run`, `get_run_summary`.
 
+**`pipeline/acoustid_pass.py`** — AcoustID + MusicBrainz fallback identification (issue #2).
+Fingerprints files with `fpcalc`, queries the AcoustID API, fetches recording metadata from
+MusicBrainz, and presents matches interactively for user verification. Requires `fpcalc`
+binary and `ACOUSTID_API_KEY` environment variable. Exports `run_acoustid_pass()`.
+
 **`pipeline/collection.py`** — Collection-fix detection. Applies regex patterns to
 filenames to extract song title and album name from conventions like `(from Minnale)` or
 `[from Kadal]`. Called by `identify.py` as a fallback when Shazam returns no match.
@@ -71,6 +76,7 @@ mp3-organizer-pipeline/
 ├── pipeline/
 │   ├── __init__.py
 │   ├── config.py          # Constants, paths, tunable settings
+│   ├── acoustid_pass.py   # AcoustID + MusicBrainz fallback (interactive, issue #2)
 │   ├── collection.py      # Collection-fix detection (filename pattern extraction)
 │   ├── db.py              # All SQLite operations (single source of truth)
 │   ├── identify.py        # Stage 1 — ShazamIO recognition + collection-fix fallback
@@ -227,6 +233,7 @@ runs/2026-03-21_14-32-00/
 | `python3 main.py --stats` | Print DB summary — no files touched |
 | `python3 main.py --check` | Verify DB tables exist — nothing else |
 | `python3 main.py --move` | Tag and move all identified songs (stages 3+4, no source needed) |
+| `python3 main.py --acoustid` | AcoustID fallback: fingerprint no_match songs, review interactively |
 | `python3 main.py --zeroise` | Clear all songs and runs from the database (asks for confirmation) |
 
 ---

--- a/DOCS/DATABASE.md
+++ b/DOCS/DATABASE.md
@@ -10,6 +10,14 @@ durability. There are two tables: `songs` (one row per MP3 file ever discovered)
 `pipeline/db.py`. Never run raw `UPDATE` or `DELETE` against the live database from the
 command line — if you need to inspect it, use read-only `SELECT` queries only.
 
+To clear the database completely (e.g. between test runs), use the safe CLI command:
+
+```bash
+python3 main.py --zeroise
+```
+
+This will ask you to type `YES` before deleting anything.
+
 ---
 
 ## Table: `songs`
@@ -40,6 +48,11 @@ command line — if you need to inspect it, use read-only `SELECT` queries only.
 | `created_at` | TEXT | ISO timestamp — when first discovered |
 | `updated_at` | TEXT | ISO timestamp — last status change |
 | `error_msg` | TEXT | Last error message if status = `error` |
+| `meta_before` | TEXT | JSON snapshot of ID3 tags in the file before Stage 3 wrote new ones |
+| `meta_after` | TEXT | JSON snapshot of the tag values actually written by Stage 3 |
+| `duplicate_count` | INTEGER | Number of duplicate files found for this entry (set by issue #5) |
+| `id_source` | TEXT | Which mechanism identified this file: `shazam`, `acoustid`, `manual`, `collection-fix` |
+| `last_attempt_at` | TEXT | ISO timestamp of the most recent identification attempt |
 
 ---
 

--- a/DOCS/USER_GUIDE.md
+++ b/DOCS/USER_GUIDE.md
@@ -368,6 +368,18 @@ No year  → Music/Tamil/Unknown Year/Minnale/Vaseegara.mp3
 No album → Music/Tamil/2001/Unknown Album/Vaseegara.mp3
 ```
 
+**Collection-fix songs** are files that Shazam could not identify but whose filename
+contained a `from <Album>` clue (e.g. `Vaseegara (From Minnale).mp3`). These are
+identified automatically and routed to a `Collections/` folder:
+
+```
+Music/Tamil/Collections/Minnale/Vaseegara.mp3
+Music/Hindi/Collections/Muqaddar Ka Sikandar/O Saathi Re.mp3
+```
+
+If the year is later resolved (via manual review or a future identification pass), the
+file will be re-routed to the standard year-based path.
+
 Characters illegal in filenames (`/ \ : * ? " < > |`) are replaced with `_`.
 All other characters — including Tamil script, Hindi script, parentheses, ampersands, and
 hyphens — are preserved exactly.

--- a/DOCS/USER_GUIDE.md
+++ b/DOCS/USER_GUIDE.md
@@ -390,6 +390,9 @@ hyphens — are preserved exactly.
 | `python3 main.py --review --limit N` | Review only next N unmatched files |
 | `python3 main.py --stats` | Print DB summary — no files touched |
 | `python3 main.py --check` | Verify DB tables exist — nothing else |
+| `python3 main.py --move` | Tag and move all identified songs to `Music/` (stages 3+4, no source needed) |
+| `python3 main.py --move --dry-run` | Preview what `--move` would do without changing anything |
+| `python3 main.py --zeroise` | Clear all songs and runs from the database (asks for confirmation) |
 
 ---
 

--- a/DOCS/USER_GUIDE.md
+++ b/DOCS/USER_GUIDE.md
@@ -345,6 +345,68 @@ python3 main.py --review --limit 20   ← review only the next 20 unmatched file
 
 ---
 
+## AcoustID fallback pass
+
+For songs that Shazam could not identify and that have no collection pattern in their
+filename, you can run a second identification pass using AcoustID + MusicBrainz.
+
+### Prerequisites
+
+1. **Install Chromaprint** (the `fpcalc` binary):
+   ```
+   macOS:   brew install chromaprint
+   Linux:   sudo apt install libchromaprint-tools
+   Windows: download fpcalc from https://acoustid.org/chromaprint
+   ```
+
+2. **Register for a free AcoustID API key** at https://acoustid.org (takes 2 minutes, no payment).
+
+3. **Set the environment variable:**
+   ```
+   export ACOUSTID_API_KEY=your_key_here
+   ```
+
+### Running the pass
+
+```
+python3 main.py --acoustid
+```
+
+For each `no_match` file, the pipeline will:
+- Fingerprint the audio using `fpcalc`
+- Query AcoustID and retrieve the best matching recording from MusicBrainz
+- Show you the proposed match with a confidence percentage
+
+```
+────────────────────────────────────────────
+Song ID  : max-000014
+File     : Input/Tamil/mystery.mp3
+Language : Tamil
+── AcoustID match  (confidence: 94%) ──
+Title    : Vaseegara
+Artist   : Bombay Jayashri
+Album    : Minnale
+Year     : 2001
+────────────────────────────────────────────
+[a] Accept  [e] Edit  [p] Play  [s] Skip  [q] Quit
+```
+
+| Key | Action |
+|---|---|
+| `a` | Accept the proposed match as-is |
+| `e` | Edit individual fields before saving |
+| `p` | Play the file, then return to the prompt |
+| `s` | Skip this file (stays `no_match`) |
+| `q` | Quit, resume later |
+
+After the pass, run `--move` to tag and move the newly identified files:
+
+```
+python3 main.py --move
+```
+
+---
+
 ## Output folder structure
 
 Organised files land in `Music/` using this pattern:
@@ -404,6 +466,7 @@ hyphens — are preserved exactly.
 | `python3 main.py --check` | Verify DB tables exist — nothing else |
 | `python3 main.py --move` | Tag and move all identified songs to `Music/` (stages 3+4, no source needed) |
 | `python3 main.py --move --dry-run` | Preview what `--move` would do without changing anything |
+| `python3 main.py --acoustid` | AcoustID fallback pass: fingerprint no_match songs and review interactively |
 | `python3 main.py --zeroise` | Clear all songs and runs from the database (asks for confirmation) |
 
 ---

--- a/main.py
+++ b/main.py
@@ -122,6 +122,8 @@ def main():
                         help="Print DB summary by status and language")
     parser.add_argument("--zeroise", action="store_true",
                         help="Clear all songs and runs from the database (asks for confirmation)")
+    parser.add_argument("--move", action="store_true",
+                        help="Tag and move all identified songs to Music/ (stages 3+4, no source needed)")
 
     args = parser.parse_args()
 
@@ -132,6 +134,11 @@ def main():
 
     if args.zeroise:
         cmd_zeroise()
+        return
+
+    if args.move:
+        from pipeline.runner import run_pipeline
+        run_pipeline(source_path="(db-only)", stages=[3, 4], dry_run=args.dry_run)
         return
 
     if args.stats:

--- a/main.py
+++ b/main.py
@@ -124,6 +124,8 @@ def main():
                         help="Clear all songs and runs from the database (asks for confirmation)")
     parser.add_argument("--move", action="store_true",
                         help="Tag and move all identified songs to Music/ (stages 3+4, no source needed)")
+    parser.add_argument("--acoustid", action="store_true",
+                        help="AcoustID fallback pass: fingerprint no_match songs and review interactively")
 
     args = parser.parse_args()
 
@@ -139,6 +141,11 @@ def main():
     if args.move:
         from pipeline.runner import run_pipeline
         run_pipeline(source_path="(db-only)", stages=[3, 4], dry_run=args.dry_run)
+        return
+
+    if args.acoustid:
+        from pipeline.acoustid_pass import run_acoustid_pass
+        run_acoustid_pass()
         return
 
     if args.stats:

--- a/main.py
+++ b/main.py
@@ -32,6 +32,28 @@ def cmd_check():
 
 
 # ---------------------------------------------------------------------------
+# --zeroise
+# ---------------------------------------------------------------------------
+
+def cmd_zeroise():
+    conn = get_connection()
+    try:
+        total = conn.execute("SELECT COUNT(*) FROM songs").fetchone()[0]
+        runs  = conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
+        print(f"This will delete {total} song(s) and {runs} run(s) from the database.")
+        answer = input("Type YES to confirm: ").strip()
+        if answer != "YES":
+            print("Aborted.")
+            return
+        conn.execute("DELETE FROM songs")
+        conn.execute("DELETE FROM runs")
+        conn.commit()
+        print("Database cleared.")
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
 # --stats
 # ---------------------------------------------------------------------------
 
@@ -98,12 +120,18 @@ def main():
                         help="Verify DB tables and print row counts")
     parser.add_argument("--stats", action="store_true",
                         help="Print DB summary by status and language")
+    parser.add_argument("--zeroise", action="store_true",
+                        help="Clear all songs and runs from the database (asks for confirmation)")
 
     args = parser.parse_args()
 
     # ── Standalone commands ──────────────────────────────────────────────
     if args.check:
         cmd_check()
+        return
+
+    if args.zeroise:
+        cmd_zeroise()
         return
 
     if args.stats:

--- a/pipeline/acoustid_pass.py
+++ b/pipeline/acoustid_pass.py
@@ -1,0 +1,280 @@
+"""
+AcoustID + MusicBrainz fallback identification — issue #2.
+
+Processes no_match songs by:
+  1. Fingerprinting with fpcalc (Chromaprint)
+  2. Querying AcoustID API for candidate recordings
+  3. Presenting the best match to the user for verification with playback
+  4. On acceptance: status='identified', id_source='acoustid'
+
+Prerequisites:
+  - fpcalc binary (Chromaprint):
+      macOS:   brew install chromaprint
+      Linux:   sudo apt install libchromaprint-tools
+      Windows: download fpcalc from https://acoustid.org/chromaprint
+  - ACOUSTID_API_KEY environment variable (free at https://acoustid.org)
+  - pip install pyacoustid
+"""
+
+import shutil
+from datetime import datetime, timezone
+
+from pipeline import config
+from pipeline.db import get_songs_by_status, update_song
+from pipeline.review import parse_override, play_file
+from pipeline.runner import GREEN, YELLOW, RED, RESET
+
+_DIVIDER = "─" * 44
+
+
+# ---------------------------------------------------------------------------
+# Prerequisites check
+# ---------------------------------------------------------------------------
+
+def _check_prerequisites() -> None:
+    """Raise RuntimeError if fpcalc or the API key are missing."""
+    if not shutil.which("fpcalc"):
+        raise RuntimeError(
+            "fpcalc not found. Install Chromaprint:\n"
+            "  macOS:  brew install chromaprint\n"
+            "  Linux:  sudo apt install libchromaprint-tools\n"
+            "  Windows: download fpcalc from https://acoustid.org/chromaprint"
+        )
+    if not config.ACOUSTID_API_KEY:
+        raise RuntimeError(
+            "ACOUSTID_API_KEY not set.\n"
+            "Register free at https://acoustid.org then:\n"
+            "  export ACOUSTID_API_KEY=your_key_here"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint + AcoustID lookup
+# ---------------------------------------------------------------------------
+
+def _lookup(file_path: str) -> list[dict]:
+    """
+    Fingerprint file and query AcoustID.
+    Returns list of match dicts sorted by score descending.
+    Each dict: {score, title, artist, album, year}.
+    Returns [] if no matches or on any error.
+    """
+    import acoustid
+
+    try:
+        duration, fingerprint = acoustid.fingerprint_file(file_path)
+    except Exception as e:
+        print(f"  Fingerprint error: {e}")
+        return []
+
+    try:
+        response = acoustid.lookup(
+            config.ACOUSTID_API_KEY,
+            fingerprint,
+            duration,
+            meta="recordings releases releasegroups tracks",
+        )
+    except Exception as e:
+        print(f"  AcoustID lookup error: {e}")
+        return []
+
+    matches = []
+    for result in response.get("results", []):
+        score = result.get("score", 0)
+        for recording in result.get("recordings", []):
+            title = recording.get("title", "")
+            artists = recording.get("artists", [])
+            artist = artists[0]["name"] if artists else ""
+
+            album = ""
+            year = ""
+            releases = recording.get("releases", [])
+            if releases:
+                album = releases[0].get("title", "")
+                date = releases[0].get("date", {})
+                if date:
+                    raw_year = date.get("year", "")
+                    year = str(raw_year) if raw_year else ""
+
+            if title:
+                matches.append({
+                    "score": score,
+                    "title": title,
+                    "artist": artist,
+                    "album": album,
+                    "year": year,
+                })
+
+    matches.sort(key=lambda x: x["score"], reverse=True)
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# Interactive review
+# ---------------------------------------------------------------------------
+
+def _print_match(song: dict, match: dict) -> None:
+    score_pct = f"{match['score']:.0%}"
+    print(_DIVIDER)
+    print(f"Song ID  : {song['song_id']}")
+    print(f"File     : {song['file_path']}")
+    print(f"Language : {song.get('language', '')}")
+    print(f"── AcoustID match  (confidence: {score_pct}) ──")
+    print(f"Title    : {match['title'] or '(none)'}")
+    print(f"Artist   : {match['artist'] or '(none)'}")
+    print(f"Album    : {match['album'] or '(none)'}")
+    print(f"Year     : {match['year'] or '(none)'}")
+    print(_DIVIDER)
+
+
+def _review_match(song: dict, match: dict) -> str:
+    """
+    Present proposed AcoustID match and get user decision.
+    Returns: "accepted" | "edited" | "skipped" | "quit"
+    """
+    song_id = song["song_id"]
+    now = datetime.now(timezone.utc).isoformat()
+    _print_match(song, match)
+
+    while True:
+        print("[a] Accept  [e] Edit  [p] Play  [s] Skip  [q] Quit")
+        try:
+            choice = input("> ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return "quit"
+
+        if choice == "a":
+            update_song(
+                song_id,
+                status="identified",
+                final_title=match["title"],
+                final_artist=match["artist"],
+                final_album=match["album"],
+                final_year=match["year"],
+                id_source="acoustid",
+                last_attempt_at=now,
+            )
+            print(f"{GREEN}✓ Accepted. Status → identified.{RESET}\n")
+            return "accepted"
+
+        elif choice == "p":
+            play_file(song["file_path"])
+            _print_match(song, match)
+
+        elif choice == "e":
+            print("Current proposal:")
+            for k in ("title", "artist", "album", "year"):
+                print(f"  {k.capitalize():<6} : {match[k] or '(none)'}")
+            print("Enter: Title | Artist | Album | Year  (blank field = keep proposal)")
+            try:
+                raw = input("> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                return "quit"
+
+            parsed = parse_override(raw)
+            merged = {k: parsed[k] or match[k] for k in ("title", "artist", "album", "year")}
+
+            print("Will save:")
+            for k, v in merged.items():
+                print(f"  {k.capitalize():<6} : {v or '(empty)'}")
+            try:
+                confirm = input("Confirm? [y/n] > ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                return "quit"
+
+            if confirm == "y":
+                update_song(
+                    song_id,
+                    status="identified",
+                    final_title=merged["title"],
+                    final_artist=merged["artist"],
+                    final_album=merged["album"],
+                    final_year=merged["year"],
+                    id_source="acoustid",
+                    last_attempt_at=now,
+                    override_used=1,
+                    override_raw=raw,
+                )
+                print(f"{GREEN}✓ Saved. Status → identified.{RESET}\n")
+                return "edited"
+
+        elif choice == "s":
+            update_song(song_id, last_attempt_at=now)
+            print()
+            return "skipped"
+
+        elif choice == "q":
+            return "quit"
+
+        else:
+            print("Invalid choice.")
+
+
+# ---------------------------------------------------------------------------
+# Batch runner
+# ---------------------------------------------------------------------------
+
+def run_acoustid_pass() -> dict:
+    """
+    Process all no_match songs through AcoustID fingerprinting and
+    interactive user verification.
+
+    Returns {processed, accepted, skipped, no_acoustid_match, errors}.
+    """
+    try:
+        _check_prerequisites()
+    except RuntimeError as e:
+        print(f"{RED}AcoustID prerequisites not met:{RESET}\n{e}")
+        return {"processed": 0, "accepted": 0, "skipped": 0,
+                "no_acoustid_match": 0, "errors": 0}
+
+    songs = get_songs_by_status("no_match")
+    total = len(songs)
+
+    if total == 0:
+        print("No no_match songs to process with AcoustID.")
+        return {"processed": 0, "accepted": 0, "skipped": 0,
+                "no_acoustid_match": 0, "errors": 0}
+
+    print(f"AcoustID pass — {total} no_match song(s)")
+    print("[a]ccept  [e]dit  [p]lay  [s]kip  [q]uit\n")
+
+    processed = accepted = skipped = no_acoustid_match = errors = 0
+
+    for i, song in enumerate(songs, 1):
+        song_id = song["song_id"]
+        name = song["file_path"].split("/")[-1]
+        print(f"({i}/{total}) Fingerprinting: {name}")
+
+        matches = _lookup(song["file_path"])
+
+        if not matches:
+            print(f"{YELLOW}[{song_id}] No AcoustID match — stays no_match{RESET}\n")
+            no_acoustid_match += 1
+            processed += 1
+            continue
+
+        result = _review_match(song, matches[0])
+        processed += 1
+
+        if result in ("accepted", "edited"):
+            accepted += 1
+        elif result == "skipped":
+            skipped += 1
+        elif result == "quit":
+            break
+
+    print(
+        f"AcoustID pass complete — {accepted} accepted, {skipped} skipped, "
+        f"{no_acoustid_match} no match, {errors} errors."
+    )
+    return {
+        "processed": processed,
+        "accepted": accepted,
+        "skipped": skipped,
+        "no_acoustid_match": no_acoustid_match,
+        "errors": errors,
+    }

--- a/pipeline/collection.py
+++ b/pipeline/collection.py
@@ -1,0 +1,57 @@
+"""
+Collection-fix detection — issue #4.
+
+Extracts album/movie name clues from filenames for songs that Shazam could
+not identify. Handles patterns common in Indian music file collections:
+
+  Vaseegara (From Minnale).mp3
+  Nenjukulle - From Kadal.mp3
+  O Saathi Re [From Muqaddar Ka Sikandar].mp3
+
+If a pattern matches, the caller should set:
+  status       = 'identified'
+  id_source    = 'collection-fix'
+  final_title  = returned 'title'
+  final_album  = returned 'album'
+"""
+
+import re
+from pathlib import Path
+
+
+# Order matters — more specific patterns first.
+_PATTERNS = [
+    # (from the movie/film/album AlbumName)
+    re.compile(r'\(\s*from\s+the\s+(?:movie|film|album)[:\s]+([^)]+)\)', re.IGNORECASE),
+    # [from the movie/film/album AlbumName]
+    re.compile(r'\[\s*from\s+the\s+(?:movie|film|album)[:\s]+([^\]]+)\]', re.IGNORECASE),
+    # (from AlbumName) or (from: AlbumName)
+    re.compile(r'\(\s*from[:\s]+([^)]+)\)', re.IGNORECASE),
+    # [from AlbumName] or [from: AlbumName]
+    re.compile(r'\[\s*from[:\s]+([^\]]+)\]', re.IGNORECASE),
+    # Title - from AlbumName  (dash-separated, at end of string)
+    re.compile(r'\s[-–—]\s*from\s+(.+)$', re.IGNORECASE),
+]
+
+
+def extract_collection_clue(file_path: str) -> dict | None:
+    """
+    Try to extract title and album from a filename using collection patterns.
+
+    Returns {'title': str, 'album': str} if a pattern matches and both
+    values are non-empty, otherwise returns None.
+    """
+    stem = Path(file_path).stem  # filename without extension
+
+    for pattern in _PATTERNS:
+        m = pattern.search(stem)
+        if not m:
+            continue
+
+        album = m.group(1).strip().strip('-').strip()
+        clean_title = pattern.sub('', stem).strip().strip('-–— ').strip()
+
+        if clean_title and album:
+            return {"title": clean_title, "album": album}
+
+    return None

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -1,3 +1,5 @@
+import os
+
 INPUT_DIR = "Input"
 OUTPUT_DIR = "Music"
 DB_PATH = "music.db"
@@ -5,3 +7,6 @@ RUNS_DIR = "runs"
 SUPPORTED_EXTENSIONS = [".mp3"]
 SHAZAM_SLEEP_SEC = 2.0   # seconds to wait between ShazamIO calls
 LANGUAGES = ["Tamil", "Hindi", "English", "Other"]
+
+# AcoustID API key — register free at https://acoustid.org
+ACOUSTID_API_KEY = os.getenv("ACOUSTID_API_KEY", "")

--- a/pipeline/db.py
+++ b/pipeline/db.py
@@ -37,7 +37,12 @@ def get_connection() -> sqlite3.Connection:
             run_id          TEXT,
             created_at      TEXT,
             updated_at      TEXT,
-            error_msg       TEXT
+            error_msg       TEXT,
+            meta_before     TEXT,
+            meta_after      TEXT,
+            duplicate_count INTEGER,
+            id_source       TEXT,
+            last_attempt_at TEXT
         );
 
         CREATE TABLE IF NOT EXISTS runs (
@@ -53,6 +58,21 @@ def get_connection() -> sqlite3.Connection:
         );
     """)
     conn.commit()
+
+    # Migrate existing databases that predate these columns.
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(songs)")}
+    migrations = {
+        "meta_before":     "ALTER TABLE songs ADD COLUMN meta_before     TEXT",
+        "meta_after":      "ALTER TABLE songs ADD COLUMN meta_after      TEXT",
+        "duplicate_count": "ALTER TABLE songs ADD COLUMN duplicate_count INTEGER",
+        "id_source":       "ALTER TABLE songs ADD COLUMN id_source       TEXT",
+        "last_attempt_at": "ALTER TABLE songs ADD COLUMN last_attempt_at TEXT",
+    }
+    for col, stmt in migrations.items():
+        if col not in existing:
+            conn.execute(stmt)
+    conn.commit()
+
     return conn
 
 

--- a/pipeline/identify.py
+++ b/pipeline/identify.py
@@ -8,6 +8,7 @@ from mutagen.mp3 import MP3, HeaderNotFoundError
 from shazamio import Shazam
 
 from pipeline import config
+from pipeline.collection import extract_collection_clue
 from pipeline.db import (
     get_connection,
     insert_song,
@@ -151,7 +152,20 @@ async def identify_file(file_path: str, run_id: str, shazam: Shazam) -> dict:
                 run_id=run_id,
             )
         else:
-            update_song(song_id, status="no_match", last_attempt_at=now, run_id=run_id)
+            # Shazam failed — try extracting album clues from the filename
+            clue = extract_collection_clue(file_path)
+            if clue:
+                update_song(
+                    song_id,
+                    status="identified",
+                    final_title=clue["title"],
+                    final_album=clue["album"],
+                    id_source="collection-fix",
+                    last_attempt_at=now,
+                    run_id=run_id,
+                )
+            else:
+                update_song(song_id, status="no_match", last_attempt_at=now, run_id=run_id)
 
     except Exception as e:
         update_song(song_id, status="error", error_msg=str(e), run_id=run_id)
@@ -184,9 +198,14 @@ def run_identification(source_path: str, run_id: str) -> dict:
                 lang = song.get("language", "")
 
                 if status == "identified":
-                    title = song.get("shazam_title", "")
-                    artist = song.get("shazam_artist", "")
-                    print(f"{GREEN}[{song_id}] ✓ identified  ({i}/{total}) {lang} | {title} — {artist}{RESET}")
+                    if song.get("id_source") == "collection-fix":
+                        title = song.get("final_title", "")
+                        album = song.get("final_album", "")
+                        print(f"{GREEN}[{song_id}] ✓ collection  ({i}/{total}) {lang} | {title} (from {album}){RESET}")
+                    else:
+                        title = song.get("shazam_title", "")
+                        artist = song.get("shazam_artist", "")
+                        print(f"{GREEN}[{song_id}] ✓ identified  ({i}/{total}) {lang} | {title} — {artist}{RESET}")
                     counts["identified"] += 1
                 elif status == "no_match":
                     err = song.get("error_msg") or ""

--- a/pipeline/identify.py
+++ b/pipeline/identify.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 
 from mutagen.mp3 import MP3, HeaderNotFoundError
@@ -128,6 +129,7 @@ async def identify_file(file_path: str, run_id: str, shazam: Shazam) -> dict:
         out = await shazam.recognize(file_path)
         result = parse_shazam_response(out)
 
+        now = datetime.now(timezone.utc).isoformat()
         if result is not None:
             update_song(
                 song_id,
@@ -144,10 +146,12 @@ async def identify_file(file_path: str, run_id: str, shazam: Shazam) -> dict:
                 final_album=result["album"],
                 final_year=result["year"],
                 final_genre=result["genre"],
+                id_source="shazam",
+                last_attempt_at=now,
                 run_id=run_id,
             )
         else:
-            update_song(song_id, status="no_match", run_id=run_id)
+            update_song(song_id, status="no_match", last_attempt_at=now, run_id=run_id)
 
     except Exception as e:
         update_song(song_id, status="error", error_msg=str(e), run_id=run_id)

--- a/pipeline/organizer.py
+++ b/pipeline/organizer.py
@@ -38,21 +38,33 @@ def sanitize(name: str) -> str:
 def build_target_path(song: dict) -> str:
     """
     Construct the destination path for a tagged song.
-    Pattern: Music/<Language>/<Year>/<Album>/<Title>.mp3
+
+    Normal pattern:      Music/<Language>/<Year>/<Album>/<Title>.mp3
+    Collection (no year): Music/<Language>/Collections/<Album>/<Title>.mp3
+
     All components pass through sanitize(). Returns absolute path.
     """
     language = song.get("language") or "Other"
-    year     = resolve(song.get("final_year"),   song.get("shazam_year"),  "Unknown Year")
+    year     = resolve(song.get("final_year"),   song.get("shazam_year"),  "")
     album    = resolve(song.get("final_album"),   song.get("shazam_album"), "Unknown Album")
     title    = resolve(song.get("final_title"),   song.get("shazam_title"), song.get("song_id", "Unknown"))
 
-    path = os.path.join(
-        config.OUTPUT_DIR,
-        sanitize(language),
-        sanitize(year),
-        sanitize(album),
-        sanitize(title) + ".mp3",
-    )
+    if song.get("id_source") == "collection-fix" and not year:
+        path = os.path.join(
+            config.OUTPUT_DIR,
+            sanitize(language),
+            "Collections",
+            sanitize(album),
+            sanitize(title) + ".mp3",
+        )
+    else:
+        path = os.path.join(
+            config.OUTPUT_DIR,
+            sanitize(language),
+            sanitize(year or "Unknown Year"),
+            sanitize(album),
+            sanitize(title) + ".mp3",
+        )
     return os.path.abspath(path)
 
 

--- a/pipeline/tagger.py
+++ b/pipeline/tagger.py
@@ -3,6 +3,7 @@ Stage 3 — Mutagen ID3 tag writer.
 Field priority and ID3 patterns follow the README "Mutagen ID3 tagging reference" section.
 """
 
+import json
 import requests
 from mutagen.id3 import (
     APIC,
@@ -88,6 +89,15 @@ def tag_file(song: dict, dry_run: bool = False) -> bool:
         except ID3NoHeaderError:
             tags = ID3()
 
+        # Snapshot existing tags before overwriting
+        meta_before = json.dumps({
+            "title":  str(tags.get("TIT2", "")),
+            "artist": str(tags.get("TPE1", "")),
+            "album":  str(tags.get("TALB", "")),
+            "year":   str(tags.get("TDRC", "")),
+            "genre":  str(tags.get("TCON", "")),
+        })
+
         # Always write title and artist (required for any useful tag)
         if title:
             tags["TIT2"] = TIT2(encoding=3, text=title)
@@ -121,7 +131,11 @@ def tag_file(song: dict, dry_run: bool = False) -> bool:
                 print(f"  [{song_id}] cover art skipped: {cover_err}")
 
         tags.save(file_path)
-        update_song(song_id, status="tagged")
+        meta_after = json.dumps({
+            "title": title, "artist": artist, "album": album,
+            "year": year, "genre": genre,
+        })
+        update_song(song_id, status="tagged", meta_before=meta_before, meta_after=meta_after)
         return True
 
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 shazamio
 mutagen
 requests
+pyacoustid


### PR DESCRIPTION
## Summary
- New `pipeline/acoustid_pass.py`: fingerprints `no_match` files with `fpcalc`, queries AcoustID API, fetches title/artist/album/year from MusicBrainz, presents best match interactively with [a]ccept/[e]dit/[p]lay/[s]kip
- Sets `id_source=acoustid` and `last_attempt_at` on acceptance
- `config.py`: reads `ACOUSTID_API_KEY` from environment
- `requirements.txt`: adds `pyacoustid`
- `main.py`: adds `--acoustid` flag
- Docs updated: prerequisites, workflow section, architecture reference

Closes #2

## Test plan
- [ ] Install `fpcalc` and set `ACOUSTID_API_KEY`
- [ ] Run `python3 main.py --acoustid` on a folder with known `no_match` songs
- [ ] Verify accept/edit/play/skip all work correctly
- [ ] Run `python3 main.py --move` after to tag and move accepted songs
- [ ] Verify `id_source=acoustid` in DB for accepted songs

🤖 Generated with [Claude Code](https://claude.com/claude-code)