### PR TITLE
feat: filename-based MusicBrainz search fallback (#3)

### DIFF
--- a/DOCS/ARCHITECTURE.md
+++ b/DOCS/ARCHITECTURE.md
@@ -31,6 +31,11 @@ and write to `music.db` goes through a function in this module. No other module 
 SQL. Exports: `get_connection`, `generate_song_id`, `insert_song`, `update_song`,
 `get_songs_by_status`, `song_exists_by_hash`, `create_run`, `finish_run`, `get_run_summary`.
 
+**`pipeline/filename_pass.py`** — Filename-based identification (issue #3). Cleans
+filenames (strips track numbers, underscores, brackets), searches MusicBrainz text
+search API, and presents up to 3 candidates for interactive user verification.
+No API key required. Exports `run_filename_pass()`.
+
 **`pipeline/collection.py`** — Collection-fix detection. Applies regex patterns to
 filenames to extract song title and album name from conventions like `(from Minnale)` or
 `[from Kadal]`. Called by `identify.py` as a fallback when Shazam returns no match.
@@ -72,6 +77,7 @@ mp3-organizer-pipeline/
 │   ├── __init__.py
 │   ├── config.py          # Constants, paths, tunable settings
 │   ├── collection.py      # Collection-fix detection (filename pattern extraction)
+│   ├── filename_pass.py   # MusicBrainz text search fallback (interactive, issue #3)
 │   ├── db.py              # All SQLite operations (single source of truth)
 │   ├── identify.py        # Stage 1 — ShazamIO recognition + collection-fix fallback
 │   ├── review.py          # Stage 2 — Interactive manual review CLI
@@ -227,6 +233,7 @@ runs/2026-03-21_14-32-00/
 | `python3 main.py --stats` | Print DB summary — no files touched |
 | `python3 main.py --check` | Verify DB tables exist — nothing else |
 | `python3 main.py --move` | Tag and move all identified songs (stages 3+4, no source needed) |
+| `python3 main.py --filename-match` | Filename search pass: query MusicBrainz, review interactively |
 | `python3 main.py --zeroise` | Clear all songs and runs from the database (asks for confirmation) |
 
 ---

--- a/DOCS/USER_GUIDE.md
+++ b/DOCS/USER_GUIDE.md
@@ -345,6 +345,47 @@ python3 main.py --review --limit 20   ← review only the next 20 unmatched file
 
 ---
 
+## Filename search pass
+
+For files that Shazam failed on, a third pass searches MusicBrainz using the
+cleaned filename as a text query. No API key or binary dependency required.
+
+```
+python3 main.py --filename-match
+```
+
+For each `no_match` file the pipeline cleans the filename and shows up to 3 candidates:
+
+```
+────────────────────────────────────────────
+Song ID  : max-000021
+File     : Input/Hindi/01_o_saathi_re.mp3
+Language : Hindi
+Search   : 'o saathi re'
+── MusicBrainz candidates ──
+  [1]  92%  O Saathi Re — Kishore Kumar  |  Muqaddar Ka Sikandar  1978
+  [2]  74%  O Saathi Re — Lata Mangeshkar  |  Compilation  1985
+  [3]  61%  O Saathi Re (Remix) — Various  |  Remix Album
+────────────────────────────────────────────
+[1/2/3] Pick  [e] Edit manually  [p] Play  [s] Skip  [q] Quit
+```
+
+| Key | Action |
+|---|---|
+| `1` / `2` / `3` | Accept that candidate as-is |
+| `e` | Enter metadata manually (Title \| Artist \| Album \| Year) |
+| `p` | Play the file, then return to the prompt |
+| `s` | Skip (file stays `no_match`) |
+| `q` | Quit, resume later |
+
+After the pass, run `--move` to tag and move newly identified files:
+
+```
+python3 main.py --move
+```
+
+---
+
 ## Output folder structure
 
 Organised files land in `Music/` using this pattern:
@@ -404,6 +445,7 @@ hyphens — are preserved exactly.
 | `python3 main.py --check` | Verify DB tables exist — nothing else |
 | `python3 main.py --move` | Tag and move all identified songs to `Music/` (stages 3+4, no source needed) |
 | `python3 main.py --move --dry-run` | Preview what `--move` would do without changing anything |
+| `python3 main.py --filename-match` | Filename search pass: query MusicBrainz with cleaned filenames, review interactively |
 | `python3 main.py --zeroise` | Clear all songs and runs from the database (asks for confirmation) |
 
 ---

--- a/main.py
+++ b/main.py
@@ -124,6 +124,8 @@ def main():
                         help="Clear all songs and runs from the database (asks for confirmation)")
     parser.add_argument("--move", action="store_true",
                         help="Tag and move all identified songs to Music/ (stages 3+4, no source needed)")
+    parser.add_argument("--filename-match", action="store_true", dest="filename_match",
+                        help="Filename search pass: query MusicBrainz with cleaned filenames, review interactively")
 
     args = parser.parse_args()
 
@@ -139,6 +141,11 @@ def main():
     if args.move:
         from pipeline.runner import run_pipeline
         run_pipeline(source_path="(db-only)", stages=[3, 4], dry_run=args.dry_run)
+        return
+
+    if args.filename_match:
+        from pipeline.filename_pass import run_filename_pass
+        run_filename_pass()
         return
 
     if args.stats:

--- a/pipeline/filename_pass.py
+++ b/pipeline/filename_pass.py
@@ -1,0 +1,276 @@
+"""
+Filename-based identification — issue #3.
+
+Third identification pass for files that Shazam and AcoustID both failed on.
+Cleans the filename and searches the MusicBrainz text search API for candidate
+recordings. Presents up to 3 matches for manual verification with playback.
+
+No API key or binary dependency required — MusicBrainz has a free, open API.
+Sets id_source='filename-match' on acceptance.
+"""
+
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+from pipeline.db import get_songs_by_status, update_song
+from pipeline.review import parse_override, play_file
+from pipeline.runner import GREEN, YELLOW, RED, RESET
+
+_DIVIDER = "─" * 44
+_MB_URL = "https://musicbrainz.org/ws/2/recording/"
+_MB_USER_AGENT = "mp3-organizer-pipeline/1.0 ( https://github.com/fordevices/mp3-organizer-pipeline )"
+_MB_SLEEP = 1.1   # MusicBrainz rate limit: 1 request/second
+
+
+# ---------------------------------------------------------------------------
+# Filename cleaning
+# ---------------------------------------------------------------------------
+
+# Patterns to strip before searching (track numbers, common junk)
+_STRIP_PATTERNS = [
+    re.compile(r'^track\d+[\s._\-]+', re.IGNORECASE),  # "track03 ", "track03-"
+    re.compile(r'^\d{1,3}[\s._\-]+'),                  # leading track number: "01 ", "01-"
+    re.compile(r'\(\s*\d{4}\s*\)'),                    # year in parens: (2001)
+    re.compile(r'\[.*?\]'),                            # anything in square brackets
+    re.compile(r'_+'),                                 # underscores → spaces (applied last)
+]
+
+
+def clean_filename(file_path: str) -> str:
+    """
+    Strip extension and common noise from a filename to produce a search term.
+    E.g. '01_vaseegara_minnale_[320kbps].mp3' → 'vaseegara minnale'
+    """
+    stem = Path(file_path).stem
+    for pattern in _STRIP_PATTERNS[:-1]:   # all but underscore replacement
+        stem = pattern.sub(' ', stem)
+    stem = _STRIP_PATTERNS[-1].sub(' ', stem)   # underscores → spaces
+    return stem.strip(' -.')
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz search
+# ---------------------------------------------------------------------------
+
+def _search_musicbrainz(query: str) -> list[dict]:
+    """
+    Search MusicBrainz recordings for the given query string.
+    Returns up to 3 matches as dicts: {score, title, artist, album, year}.
+    Returns [] on any error.
+    """
+    try:
+        resp = requests.get(
+            _MB_URL,
+            params={"query": query, "fmt": "json", "limit": 5},
+            headers={"User-Agent": _MB_USER_AGENT},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        print(f"  MusicBrainz search error: {e}")
+        return []
+
+    matches = []
+    for recording in data.get("recordings", []):
+        score = int(recording.get("score", 0))
+        title = recording.get("title", "")
+        artists = recording.get("artist-credit", [])
+        artist = artists[0]["artist"]["name"] if artists else ""
+
+        album = ""
+        year = ""
+        releases = recording.get("releases", [])
+        if releases:
+            album = releases[0].get("title", "")
+            date = releases[0].get("date", "")
+            year = date[:4] if date else ""   # date is "YYYY-MM-DD" or "YYYY"
+
+        if title:
+            matches.append({
+                "score": score,
+                "title": title,
+                "artist": artist,
+                "album": album,
+                "year": year,
+            })
+
+    return matches[:3]
+
+
+# ---------------------------------------------------------------------------
+# Interactive review
+# ---------------------------------------------------------------------------
+
+def _print_candidates(song: dict, query: str, matches: list[dict]) -> None:
+    print(_DIVIDER)
+    print(f"Song ID  : {song['song_id']}")
+    print(f"File     : {song['file_path']}")
+    print(f"Language : {song.get('language', '')}")
+    print(f"Search   : {query!r}")
+    print(f"── MusicBrainz candidates ──")
+    for i, m in enumerate(matches, 1):
+        print(f"  [{i}] {m['score']:>3}%  {m['title']} — {m['artist']}"
+              f"  |  {m['album'] or '(no album)'}  {m['year'] or ''}")
+    print(_DIVIDER)
+
+
+def _review_candidates(song: dict, query: str, matches: list[dict]) -> str:
+    """
+    Let user pick a candidate, edit, play, skip, or quit.
+    Returns: "accepted" | "edited" | "skipped" | "quit"
+    """
+    song_id = song["song_id"]
+    now = datetime.now(timezone.utc).isoformat()
+    _print_candidates(song, query, matches)
+
+    options = "/".join(str(i) for i in range(1, len(matches) + 1))
+    while True:
+        print(f"[{options}] Pick  [e] Edit manually  [p] Play  [s] Skip  [q] Quit")
+        try:
+            choice = input("> ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return "quit"
+
+        # Number pick
+        if choice.isdigit() and 1 <= int(choice) <= len(matches):
+            match = matches[int(choice) - 1]
+            update_song(
+                song_id,
+                status="identified",
+                final_title=match["title"],
+                final_artist=match["artist"],
+                final_album=match["album"],
+                final_year=match["year"],
+                id_source="filename-match",
+                last_attempt_at=now,
+            )
+            print(f"{GREEN}✓ Accepted [{choice}]. Status → identified.{RESET}\n")
+            return "accepted"
+
+        elif choice == "p":
+            play_file(song["file_path"])
+            _print_candidates(song, query, matches)
+
+        elif choice == "e":
+            print("Enter: Title | Artist | Album | Year")
+            try:
+                raw = input("> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                return "quit"
+
+            if not raw:
+                print("No changes.")
+                continue
+
+            parsed = parse_override(raw)
+            print("Will save:")
+            for k in ("title", "artist", "album", "year"):
+                print(f"  {k.capitalize():<6} : {parsed[k] or '(empty)'}")
+            try:
+                confirm = input("Confirm? [y/n] > ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                return "quit"
+
+            if confirm == "y":
+                update_song(
+                    song_id,
+                    status="identified",
+                    final_title=parsed["title"],
+                    final_artist=parsed["artist"],
+                    final_album=parsed["album"],
+                    final_year=parsed["year"],
+                    id_source="filename-match",
+                    last_attempt_at=now,
+                    override_used=1,
+                    override_raw=raw,
+                )
+                print(f"{GREEN}✓ Saved. Status → identified.{RESET}\n")
+                return "edited"
+
+        elif choice == "s":
+            update_song(song_id, last_attempt_at=now)
+            print()
+            return "skipped"
+
+        elif choice == "q":
+            return "quit"
+
+        else:
+            print("Invalid choice.")
+
+
+# ---------------------------------------------------------------------------
+# Batch runner
+# ---------------------------------------------------------------------------
+
+def run_filename_pass() -> dict:
+    """
+    Process all no_match songs by searching MusicBrainz with their cleaned
+    filename and presenting candidates for manual verification.
+
+    Returns {processed, accepted, skipped, no_mb_match, errors}.
+    """
+    songs = get_songs_by_status("no_match")
+    total = len(songs)
+
+    if total == 0:
+        print("No no_match songs to process with filename search.")
+        return {"processed": 0, "accepted": 0, "skipped": 0,
+                "no_mb_match": 0, "errors": 0}
+
+    print(f"Filename pass — {total} no_match song(s)")
+    print("[1/2/3] Pick candidate  [e]dit  [p]lay  [s]kip  [q]uit\n")
+
+    processed = accepted = skipped = no_mb_match = errors = 0
+
+    for i, song in enumerate(songs, 1):
+        song_id = song["song_id"]
+        query = clean_filename(song["file_path"])
+        print(f"({i}/{total}) Searching: {query!r}")
+
+        if not query:
+            print(f"{YELLOW}[{song_id}] Filename too short to search — skipped{RESET}\n")
+            no_mb_match += 1
+            processed += 1
+            continue
+
+        matches = _search_musicbrainz(query)
+
+        if not matches:
+            print(f"{YELLOW}[{song_id}] No MusicBrainz match — stays no_match{RESET}\n")
+            no_mb_match += 1
+            processed += 1
+        else:
+            result = _review_candidates(song, query, matches)
+            processed += 1
+
+            if result in ("accepted", "edited"):
+                accepted += 1
+            elif result == "skipped":
+                skipped += 1
+            elif result == "quit":
+                break
+
+        # Respect MusicBrainz rate limit between requests
+        if i < total:
+            time.sleep(_MB_SLEEP)
+
+    print(
+        f"Filename pass complete — {accepted} accepted, {skipped} skipped, "
+        f"{no_mb_match} no match, {errors} errors."
+    )
+    return {
+        "processed": processed,
+        "accepted": accepted,
+        "skipped": skipped,
+        "no_mb_match": no_mb_match,
+        "errors": errors,
+    }


### PR DESCRIPTION
## Summary
- New `pipeline/filename_pass.py`: cleans filenames (strips track numbers, brackets, underscores, years in parens), searches MusicBrainz text API, presents up to 3 scored candidates for interactive [1/2/3] pick / [e]dit / [p]lay / [s]kip
- Sets `id_source=filename-match` and `last_attempt_at` on acceptance
- Respects MusicBrainz rate limit (1 req/sec), no API key or binary required
- `main.py`: adds `--filename-match` flag
- Docs updated in USER_GUIDE.md and ARCHITECTURE.md

Closes #3

## Test plan
- [ ] Run `python3 main.py --filename-match` on a folder with known `no_match` songs
- [ ] Verify filename cleaning strips track numbers, brackets, underscores correctly
- [ ] Verify MusicBrainz candidates appear with score percentages
- [ ] Verify pick/edit/play/skip all work correctly
- [ ] Run `python3 main.py --move` after to tag and move accepted songs
- [ ] Verify `id_source=filename-match` in DB for accepted songs

🤖 Generated with [Claude Code](https://claude.com/claude-code)