### PR TITLE
feat: duplicate detection and Duplicates/ routing (#5)

### DIFF
--- a/DOCS/ARCHITECTURE.md
+++ b/DOCS/ARCHITECTURE.md
@@ -175,6 +175,16 @@ Missing fields fall back gracefully:
 - No album → `Unknown Album`
 - No title → `song_id` (e.g. `max-000042`)
 
+**Duplicate songs** (same title+artist+language as an already-done song) go to:
+
+```
+Music/<Language>/Duplicates/<Album>/<Title> (<song_id>).mp3
+```
+
+The song_id suffix distinguishes multiple duplicates of the same track. The original
+song's `duplicate_count` in the DB is incremented each time a duplicate is found.
+The `--review` command shows a duplicate count warning on affected songs.
+
 **Collection-fix songs** (identified from filename patterns, no year known) go to:
 
 ```

--- a/DOCS/USER_GUIDE.md
+++ b/DOCS/USER_GUIDE.md
@@ -453,6 +453,16 @@ Music/Hindi/1974/Roti Kapda Aur Makaan/Aaj Ki Raat.mp3
 Music/English/1999/Issues/Evolution.mp3
 ```
 
+**Duplicate songs** (same title+artist+language already exists in `Music/`) are automatically
+routed to a `Duplicates/` folder for manual comparison:
+
+```
+Music/Tamil/Duplicates/Minnale/Vaseegara (max-000031).mp3
+```
+
+The original stays in its normal path. Open both files in a player, keep the
+better-quality one, and delete the other.
+
 Missing fields fall back gracefully:
 
 ```

--- a/pipeline/db.py
+++ b/pipeline/db.py
@@ -181,6 +181,44 @@ def finish_run(
         conn.close()
 
 
+def find_done_duplicate(title: str, artist: str, language: str) -> dict | None:
+    """
+    Return the first done song with matching title+artist+language, or None.
+    Comparison is case-insensitive and whitespace-trimmed.
+    Used by organizer.py to detect duplicate songs before moving.
+    """
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            """SELECT * FROM songs
+               WHERE status = 'done'
+               AND LOWER(TRIM(final_title))  = LOWER(TRIM(?))
+               AND LOWER(TRIM(final_artist)) = LOWER(TRIM(?))
+               AND LOWER(language)           = LOWER(?)
+               ORDER BY created_at ASC LIMIT 1""",
+            (title, artist, language),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def increment_duplicate_count(song_id: str) -> None:
+    """Increment duplicate_count by 1 for the given song."""
+    conn = get_connection()
+    try:
+        conn.execute(
+            """UPDATE songs
+               SET duplicate_count = COALESCE(duplicate_count, 0) + 1,
+                   updated_at = ?
+               WHERE song_id = ?""",
+            (_now(), song_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def get_run_summary(run_id: str) -> dict:
     conn = get_connection()
     try:

--- a/pipeline/identify.py
+++ b/pipeline/identify.py
@@ -11,6 +11,7 @@ from pipeline import config
 from pipeline.collection import extract_collection_clue
 from pipeline.db import (
     get_connection,
+    increment_duplicate_count,
     insert_song,
     song_exists_by_hash,
     update_song,
@@ -101,10 +102,20 @@ async def identify_file(file_path: str, run_id: str, shazam: Shazam) -> dict:
     Full Stage 1 pipeline for one file. Returns {} if the file was skipped
     (already in DB). Returns the updated song row dict otherwise.
     """
-    # 1. Dedup check
+    # 1. Dedup check — same file submitted twice
     file_hash = compute_md5(file_path)
     if song_exists_by_hash(file_hash):
-        print(f"[SKIP] already in DB: {file_path}")
+        # Track that this exact file was seen again
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT song_id FROM songs WHERE file_hash = ?", (file_hash,)
+            ).fetchone()
+            if row:
+                increment_duplicate_count(row["song_id"])
+        finally:
+            conn.close()
+        print(f"[SKIP] already in DB (duplicate file): {file_path}")
         return {}
 
     # 2. Language

--- a/pipeline/organizer.py
+++ b/pipeline/organizer.py
@@ -8,8 +8,13 @@ import re
 import shutil
 
 from pipeline import config
-from pipeline.db import get_songs_by_status, update_song
-from pipeline.runner import GREEN, RED, RESET
+from pipeline.db import (
+    find_done_duplicate,
+    get_songs_by_status,
+    increment_duplicate_count,
+    update_song,
+)
+from pipeline.runner import GREEN, RED, YELLOW, RESET
 from pipeline.tagger import resolve
 
 # ---------------------------------------------------------------------------
@@ -69,17 +74,66 @@ def build_target_path(song: dict) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Duplicate path construction
+# ---------------------------------------------------------------------------
+
+def build_duplicate_path(song: dict) -> str:
+    """
+    Path for a song identified as a duplicate of one already in Music/.
+    Pattern: Music/<Language>/Duplicates/<Album>/<Title> (<song_id>).mp3
+    The song_id suffix distinguishes multiple duplicates of the same track.
+    """
+    language = song.get("language") or "Other"
+    album    = resolve(song.get("final_album"),  song.get("shazam_album"),  "Unknown Album")
+    title    = resolve(song.get("final_title"),  song.get("shazam_title"),  song.get("song_id", "Unknown"))
+    stem     = sanitize(f"{title} ({song['song_id']})")
+
+    path = os.path.join(
+        config.OUTPUT_DIR,
+        sanitize(language),
+        "Duplicates",
+        sanitize(album),
+        stem + ".mp3",
+    )
+    return os.path.abspath(path)
+
+
+# ---------------------------------------------------------------------------
 # Single-file organizer
 # ---------------------------------------------------------------------------
 
 def organize_file(song: dict, dry_run: bool = False) -> bool:
     """
     Move one tagged song to its target path.
+    If the same title+artist+language is already done, routes to Duplicates/.
     Returns True on success (or dry_run), False on error.
     """
     song_id = song["song_id"]
     source  = song["file_path"]
-    target  = build_target_path(song)
+
+    # Check for a semantically identical song already in Music/
+    title    = resolve(song.get("final_title"),  song.get("shazam_title"),  "")
+    artist   = resolve(song.get("final_artist"), song.get("shazam_artist"), "")
+    language = song.get("language", "")
+
+    original = find_done_duplicate(title, artist, language) if (title and artist) else None
+    if original:
+        target = build_duplicate_path(song)
+        if dry_run:
+            rel = os.path.relpath(target)
+            print(f"[{song_id}] duplicate of {original['song_id']} → would move to {rel}")
+            return True
+        try:
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            shutil.move(source, target)
+            update_song(song_id, status="done", final_path=os.path.abspath(target))
+            increment_duplicate_count(original["song_id"])
+            return True
+        except Exception as e:
+            update_song(song_id, status="error", error_msg=str(e))
+            return False
+
+    target = build_target_path(song)
 
     # Already in place
     if os.path.abspath(source) == target:
@@ -94,14 +148,12 @@ def organize_file(song: dict, dry_run: bool = False) -> bool:
     try:
         os.makedirs(os.path.dirname(target), exist_ok=True)
 
-        # Collision: append (song_id) to stem
+        # Collision with unexpected file at target path — append song_id
         if os.path.exists(target):
-            title = resolve(song.get("final_title"), song.get("shazam_title"), song_id)
-            stem  = sanitize(f"{title} ({song_id})")
+            stem   = sanitize(f"{title or song_id} ({song_id})")
             target = os.path.join(os.path.dirname(target), stem + ".mp3")
             if os.path.exists(target):
-                update_song(song_id, status="error",
-                            error_msg="collision unresolvable")
+                update_song(song_id, status="error", error_msg="collision unresolvable")
                 return False
 
         shutil.move(source, target)
@@ -142,10 +194,12 @@ def run_organization(dry_run: bool = False) -> dict:
 
         if ok:
             moved += 1
-            rel = os.path.relpath(song.get("final_path") or build_target_path(song))
-            title  = resolve(song.get("final_title"),  song.get("shazam_title"),  "")
-            artist = resolve(song.get("final_artist"), song.get("shazam_artist"), "")
-            print(f"{GREEN}[{song_id}] ✓ moved   → {rel}{RESET}")
+            final_path = song.get("final_path") or build_target_path(song)
+            rel = os.path.relpath(final_path)
+            if "Duplicates" in rel:
+                print(f"{YELLOW}[{song_id}] ⓓ duplicate → {rel}{RESET}")
+            else:
+                print(f"{GREEN}[{song_id}] ✓ moved   → {rel}{RESET}")
         else:
             errors += 1
             err = song.get("error_msg", "unknown error")

--- a/pipeline/review.py
+++ b/pipeline/review.py
@@ -77,9 +77,12 @@ def format_song_header(song: dict) -> str:
 
     year_warn = _year_warning(shazam_year)
 
+    dup_count = song.get("duplicate_count") or 0
+    dup_note  = f"  ⓓ {dup_count} duplicate(s) in Music/Duplicates/" if dup_count else ""
+
     lines = [
         _DIVIDER,
-        f"Song ID  : {song_id}",
+        f"Song ID  : {song_id}{dup_note}",
         f"File     : {file_path}",
         f"Language : {language}",
         f"Status   : {status}",


### PR DESCRIPTION
## Summary
- `db.py`: two new helpers — `find_done_duplicate()` queries done songs by title+artist+language; `increment_duplicate_count()` increments the counter atomically
- `identify.py`: when a file hash already exists in DB, increments `duplicate_count` on the original before skipping
- `organizer.py`: before moving a tagged file, checks for a semantically identical done song; if found, routes to `Music/<Language>/Duplicates/<Album>/<Title> (<song_id>).mp3`, increments `duplicate_count` on the original, and prints a `⓪ duplicate` line
- `review.py`: shows `⓪ N duplicate(s) in Music/Duplicates/` in the song header when `duplicate_count > 0`
- Docs updated in USER_GUIDE.md and ARCHITECTURE.md

Closes #5

## Test plan
- [ ] Run Stage 1 on a folder containing two copies of the same song (different filenames, same content) — verify `duplicate_count` increments on the original
- [ ] Run full pipeline on two different files that identify as the same title+artist — verify second goes to `Music/<Language>/Duplicates/`
- [ ] Run `--review` on the original — verify duplicate count warning appears in header
- [ ] Verify `--move --dry-run` shows the duplicate routing without moving files

🤖 Generated with [Claude Code](https://claude.com/claude-code)